### PR TITLE
Fix GH action checks

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -3,7 +3,7 @@
 source $(dirname "$(readlink -f "$0")")/build-srpm.sh
 
 # Install build dependencies
-#dnf builddep -y rpmbuild/SRPMS/*src.rpm
+dnf builddep -y rpmbuild/SRPMS/*src.rpm
 
 # Build binary package
 rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -10,8 +10,6 @@ installdeps:
 		git \
 		java-11-openjdk-devel \
 		make \
-		maven-profile \
-		maven-plugin-registry \
 		maven-source-plugin \
 		maven-shade-plugin \
 		maven \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
         dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
         dnf install -y ovirt-release-master
 
+        # Configure CS8 repositories
+        dnf config-manager --enable powertools -y
+        dnf module enable -y javapackages-tools
+
     - name: Prepare CentOS Stream 9 environment
       if: ${{ matrix.shortcut == 'cs9' }}
       run: |
@@ -46,6 +50,7 @@ jobs:
     - name: Install required packages
       run: |
         dnf install -y \
+          gcc \
           autoconf \
           automake \
           createrepo_c \
@@ -54,8 +59,6 @@ jobs:
           git \
           java-11-openjdk-devel \
           make \
-          maven-profile \
-          maven-plugin-registry \
           maven-source-plugin \
           maven-shade-plugin \
           maven \

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ clean-local:
 	$(MVN) clean
 
 all-local:
-	$(MVN) dependency:resolve
+	$(MVN) package
 
 all-local: dist
 

--- a/java-client-kubevirt.spec.in
+++ b/java-client-kubevirt.spec.in
@@ -39,12 +39,10 @@ BuildRequires:	java-11-openjdk-devel >= 11.0.4
 
 BuildRequires:	javapackages-local
 BuildRequires:	maven >= 3.5.0
-BuildRequires:  maven-local
+BuildRequires:	maven-local
 BuildRequires:	maven-shade-plugin
 BuildRequires:	maven-source-plugin
-BuildRequires:  maven-compiler-plugin
-BuildRequires:  maven-profile
-BuildRequires:  maven-plugin-registry
+BuildRequires:	maven-compiler-plugin
 
 # All are provided by our fat jar
 Provides:	mvn(io.kubernetes:client-java) = 6.0.1


### PR DESCRIPTION
This patch replaces mvn dependency:resolve with mvn package because of
transitive dependency requirement to maven plugins not available on
Centos Stream 9 and available only in PowerTools on Centos Stream 8.

After this change maven will not try to resolve those unused (in this
case) dependencies.