### PR TITLE
Revert back to use 'mvn dependency:resolve' in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ clean-local:
 	$(MVN) clean
 
 all-local:
-	$(MVN) package
+	$(MVN) dependency:resolve
 
 all-local: dist
 

--- a/java-client-kubevirt.spec.in
+++ b/java-client-kubevirt.spec.in
@@ -40,6 +40,7 @@ BuildRequires:	java-11-openjdk-devel >= 11.0.4
 BuildRequires:	javapackages-local
 BuildRequires:	maven >= 3.5.0
 BuildRequires:	maven-local
+BuildRequires:	maven-dependency-plugin
 BuildRequires:	maven-shade-plugin
 BuildRequires:	maven-source-plugin
 BuildRequires:	maven-compiler-plugin


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
