### PR TITLE
Use oVirt buildcontainer image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,56 +16,17 @@ jobs:
         include:
           - name: centos-stream-8
             shortcut: cs8
-            container-name: stream8
+            container-name: el8stream
           - name: centos-stream-9
             shortcut: cs9
-            container-name: stream9
+            container-name: el9stream
 
     name: ${{ matrix.name }}
 
     container:
-      image: quay.io/centos/centos:${{ matrix.container-name }}
+      image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
 
     steps:
-    - name: Prepare CentOS Stream 8 environment
-      if: ${{ matrix.shortcut == 'cs8' }}
-      run: |
-        # Install oVirt repositories
-        dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
-        dnf install -y ovirt-release-master
-
-        # Configure CS8 repositories
-        dnf config-manager --enable powertools -y
-        dnf module enable -y javapackages-tools
-
-    - name: Prepare CentOS Stream 9 environment
-      if: ${{ matrix.shortcut == 'cs9' }}
-      run: |
-        # DNF core plugins are installed in the official CS9 container image
-        dnf install -y dnf-plugins-core
-
-        # Install oVirt repositories
-        dnf copr enable -y ovirt/ovirt-master-snapshot
-        dnf install -y ovirt-release-master
-
-    - name: Install required packages
-      run: |
-        dnf install -y \
-          gcc \
-          autoconf \
-          automake \
-          createrepo_c \
-          dnf-utils \
-          findutils \
-          git \
-          java-11-openjdk-devel \
-          make \
-          maven-source-plugin \
-          maven-shade-plugin \
-          maven \
-          rpm-build \
-          sed
-
     - name: Checkout sources
       uses: actions/checkout@v2
 


### PR DESCRIPTION
Use oVirt buildcontainer instead of default CentOS Stream container,
because oVirt buildcontainer already contains all required repositories
and build dependencies.

Signed-off-by: Artur Socha <asocha@redhat.com>