### PR TITLE
Bump io.kubernetes:client-java to 15.0.1

### DIFF
--- a/java-client-kubevirt.spec.in
+++ b/java-client-kubevirt.spec.in
@@ -46,7 +46,7 @@ BuildRequires:	maven-source-plugin
 BuildRequires:	maven-compiler-plugin
 
 # All are provided by our fat jar
-Provides:	mvn(io.kubernetes:client-java) = 6.0.1
+Provides:	mvn(io.kubernetes:client-java) = 15.0.1
 Provides:	mvn(io.gsonfire:gson-fire) = 1.8.3
 Provides:	mvn(javax.annotation:javax.annotation-api) = 1.3.2
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <io.k8s.version>6.0.1</io.k8s.version>
+    <io.k8s.version>15.0.1</io.k8s.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <io.gsonfire.version>1.8.3</io.gsonfire.version>
   </properties>


### PR DESCRIPTION
This bump should solve several CVEs filed on the 6.0.1 version, but
backward compatibility shouldn't be changed according to
https://github.com/kubernetes-client/java/wiki/2.-Versioning-and-Compatibility#compatibility

Signed-off-by: Martin Perina <mperina@redhat.com>
