### PR TITLE
spec: allow xmvn to fetch missing artifacts

### DIFF
--- a/java-client-kubevirt.spec.in
+++ b/java-client-kubevirt.spec.in
@@ -46,6 +46,10 @@ BuildRequires:	maven-source-plugin
 BuildRequires:	maven-compiler-plugin
 BuildRequires:	maven-clean-plugin
 BuildRequires:	maven-install-plugin
+# A few depencies are not yet packaged. Allowing xmvn to fetch them
+BuildRequires:	maven-wagon-http
+BuildRequires:	maven-resolver-connector-basic
+BuildRequires:	maven-resolver-transport-wagon
 
 # All are provided by our fat jar
 Provides:	mvn(io.kubernetes:client-java) = 6.0.1


### PR DESCRIPTION
Build is using xmvn for local build but a few deps are still not
packaged as rpm. Allowing xmvn to fetch them.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>